### PR TITLE
replace require statements with if reverts and custom errors, fix natspec and update enum order in interface

### DIFF
--- a/contracts/EverestConsumer.sol
+++ b/contracts/EverestConsumer.sol
@@ -66,7 +66,7 @@ contract EverestConsumer is IEverestConsumer, ChainlinkClient, Ownable {
         IERC20(_chainlinkTokenAddress()).safeTransferFrom(msg.sender, address(this), oraclePayment);
 
         Chainlink.Request memory request = _buildOperatorRequest(jobId, this.fulfill.selector);
-        request.addBytes("address", abi.encode(_revealee));
+        request._addBytes("address", abi.encode(_revealee));
 
         bytes32 requestId = _sendOperatorRequest(request, oraclePayment);
 

--- a/contracts/EverestConsumer.sol
+++ b/contracts/EverestConsumer.sol
@@ -67,7 +67,7 @@ contract EverestConsumer is IEverestConsumer, ChainlinkClient, Ownable {
             revert EverestConsumer__RevealeeShouldNotBeZeroAddress();
         }
 
-        IERC20(chainlinkTokenAddress()).safeTransferFrom(msg.sender, address(this), oraclePayment);
+        IERC20(_chainlinkTokenAddress()).safeTransferFrom(msg.sender, address(this), oraclePayment);
 
         Chainlink.Request memory request = _buildOperatorRequest(jobId, this.fulfill.selector);
         request.addBytes("address", abi.encode(_revealee));

--- a/contracts/EverestConsumer.sol
+++ b/contracts/EverestConsumer.sol
@@ -69,10 +69,10 @@ contract EverestConsumer is IEverestConsumer, ChainlinkClient, Ownable {
 
         IERC20(chainlinkTokenAddress()).safeTransferFrom(msg.sender, address(this), oraclePayment);
 
-        Chainlink.Request memory request = buildOperatorRequest(jobId, this.fulfill.selector);
+        Chainlink.Request memory request = _buildOperatorRequest(jobId, this.fulfill.selector);
         request.addBytes("address", abi.encode(_revealee));
 
-        bytes32 requestId = sendOperatorRequest(request, oraclePayment);
+        bytes32 requestId = _sendOperatorRequest(request, oraclePayment);
 
         uint40 expiration = uint40(block.timestamp) + OPERATOR_EXPIRATION_TIME;
         _requests[requestId] = Request({
@@ -93,7 +93,7 @@ contract EverestConsumer is IEverestConsumer, ChainlinkClient, Ownable {
     function fulfill(bytes32 _requestId, Status _status, uint40 _kycTimestamp)
         external
         override
-        recordChainlinkFulfillment(_requestId)
+        _recordChainlinkFulfillment(_requestId)
     {
         if (_status == Status.KYCUser) {
             if (_kycTimestamp == 0) {
@@ -124,7 +124,7 @@ contract EverestConsumer is IEverestConsumer, ChainlinkClient, Ownable {
         if (request.revealer != msg.sender) {
             revert EverestConsumer__NotOwnerOfRequest();
         }
-        cancelChainlinkRequest(_requestId, oraclePayment, this.fulfill.selector, request.expiration);
+        _cancelChainlinkRequest(_requestId, oraclePayment, this.fulfill.selector, request.expiration);
         IERC20(chainlinkTokenAddress()).safeTransfer(msg.sender, oraclePayment);
         request.isCanceled = true;
     }
@@ -164,11 +164,11 @@ contract EverestConsumer is IEverestConsumer, ChainlinkClient, Ownable {
     }
 
     function setOracle(address _oracle) external override onlyOwner {
-        setChainlinkOracle(_oracle);
+        _setChainlinkOracle(_oracle);
     }
 
     function setLink(address _link) external override onlyOwner {
-        setChainlinkToken(_link);
+        _setChainlinkToken(_link);
     }
 
     function setOraclePayment(uint256 _oraclePayment) external override onlyOwner {
@@ -180,11 +180,11 @@ contract EverestConsumer is IEverestConsumer, ChainlinkClient, Ownable {
     }
 
     function oracleAddress() external view override returns (address) {
-        return chainlinkOracleAddress();
+        return _chainlinkOracleAddress();
     }
 
     function linkAddress() external view override returns (address) {
-        return chainlinkTokenAddress();
+        return _chainlinkTokenAddress();
     }
 
     function stringToBytes32(string memory _source) private pure returns (bytes32) {

--- a/contracts/EverestConsumer.sol
+++ b/contracts/EverestConsumer.sol
@@ -55,8 +55,8 @@ contract EverestConsumer is IEverestConsumer, ChainlinkClient, Ownable {
         uint256 _oraclePayment,
         string memory _signUpURL
     ) {
-        setChainlinkToken(_link);
-        setChainlinkOracle(_oracle);
+        _setChainlinkToken(_link);
+        _setChainlinkOracle(_oracle);
         jobId = stringToBytes32(_jobId);
         oraclePayment = _oraclePayment;
         signUpURL = _signUpURL;

--- a/contracts/EverestConsumer.sol
+++ b/contracts/EverestConsumer.sol
@@ -93,7 +93,7 @@ contract EverestConsumer is IEverestConsumer, ChainlinkClient, Ownable {
     function fulfill(bytes32 _requestId, Status _status, uint40 _kycTimestamp)
         external
         override
-        _recordChainlinkFulfillment(_requestId)
+        recordChainlinkFulfillment(_requestId)
     {
         if (_status == Status.KYCUser) {
             if (_kycTimestamp == 0) {

--- a/contracts/EverestConsumer.sol
+++ b/contracts/EverestConsumer.sol
@@ -125,7 +125,7 @@ contract EverestConsumer is IEverestConsumer, ChainlinkClient, Ownable {
             revert EverestConsumer__NotOwnerOfRequest();
         }
         _cancelChainlinkRequest(_requestId, oraclePayment, this.fulfill.selector, request.expiration);
-        IERC20(chainlinkTokenAddress()).safeTransfer(msg.sender, oraclePayment);
+        IERC20(_chainlinkTokenAddress()).safeTransfer(msg.sender, oraclePayment);
         request.isCanceled = true;
     }
 

--- a/contracts/EverestConsumer.sol
+++ b/contracts/EverestConsumer.sol
@@ -48,13 +48,9 @@ contract EverestConsumer is IEverestConsumer, ChainlinkClient, Ownable {
         _;
     }
 
-    constructor(
-        address _link,
-        address _oracle,
-        string memory _jobId,
-        uint256 _oraclePayment,
-        string memory _signUpURL
-    ) {
+    constructor(address _link, address _oracle, string memory _jobId, uint256 _oraclePayment, string memory _signUpURL)
+        Ownable(msg.sender)
+    {
         _setChainlinkToken(_link);
         _setChainlinkOracle(_oracle);
         jobId = stringToBytes32(_jobId);

--- a/contracts/interfaces/IEverestConsumer.sol
+++ b/contracts/interfaces/IEverestConsumer.sol
@@ -6,10 +6,10 @@ interface IEverestConsumer {
     enum Status {
         // Address does not exist
         NotFound,
-        // KYC User status
-        KYCUser,
         // Human & Unique status
-        HumanAndUnique
+        HumanAndUnique,
+        // KYC User status
+        KYCUser
     }
 
     struct Request {
@@ -57,7 +57,7 @@ interface IEverestConsumer {
     /// @param _status A KYC status from the everest API response:
     /// 0 - `NotFound`: `isHumanAndUnique`=false and `isKYCUser`=false
     /// 1 - `HumanAndUnique`: `isHumanAndUnique`=true and `isKYCUser`=false
-    /// 2 - `NotFound`: `isHumanAndUnique`=true and `isKYCUser`=true
+    /// 2 - `KYCUser`: `isHumanAndUnique`=true and `isKYCUser`=true
     /// @param _kycTimestamp A KYC timestamp from the everest API response
     function fulfill(
         bytes32 _requestId,

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
   "devDependencies": {
     "@openzeppelin/test-helpers": "^0.5.15",
     "chai": "^4.3.6",
+    "eth-gas-reporter": "^0.2.25",
     "mocha": "^10.0.0",
     "prettier": "^2.7.1",
     "solhint-plugin-prettier": "^0.0.5"

--- a/truffle-config.js
+++ b/truffle-config.js
@@ -9,7 +9,15 @@ module.exports = {
         },
     },
 
-    mocha: {},
+    plugins: ["eth-gas-reporter"],
+
+    mocha: {
+        reporter: "eth-gas-reporter",
+        reporterOptions: {
+            currency: "USD", // Shows gas prices in USD
+            gasPrice: 21, // Default gas price in gwei
+        },
+    },
 
     compilers: {
         solc: {


### PR DESCRIPTION
I've replaced the require statements with if reverts and custom errors for increased gas efficiency. I had to simplify some of the tests to expect reverts in general, as opposed to the specific revert message because Truffle doesn't seem to be able to decode custom errors.
I also installed a gas reporter plugin to review the costs of deployment and each function.
Please see screenshots below of pre and post gas optimized costs, as you can see only one of the tests had an increase in gas cost but the amount was negligible compared to the overall savings.
Thanks!

_Edit_: 
I've also made some [modifications to the IEverestConsumer interface](https://github.com/EverID/everest-chainlink-consumer/pull/7/files#diff-84215e29c4ff095ea247ff0c037feba494d275f6306124b447dde985f33884bb). The natspec for `fulfill()` had mistakenly labelled `KYCUser` as `NotFound`.

In addition to this I switched the order of `HumanAndUnique` and `KYCUser` in the `Status` enum to correspond with the natspec comments and logical progression. Previously it had `NotFound` as `0`, `KYCUser` as `1`, and `HumanAndUnique` as `2`. I've modified it so `NotFound` stays as `0`, but `HumanAndUnique` is now `1`, and `KYCUser` is now `2`.

Thanks again.

With Require Statements:
<img width="982" alt="require_functions" src="https://github.com/EverID/everest-chainlink-consumer/assets/120574160/44716d66-4ecc-4256-9883-df230cd0cbe2">

<img width="982" alt="require_deployment" src="https://github.com/EverID/everest-chainlink-consumer/assets/120574160/135ab78b-7268-4a40-b275-c0b6d9e73681">

With If Reverts and Custom Errors:
<img width="982" alt="if_revert_functions" src="https://github.com/EverID/everest-chainlink-consumer/assets/120574160/6a0af8a5-5160-483d-b53e-0680d14d7b48">

<img width="982" alt="if_revert_deployment" src="https://github.com/EverID/everest-chainlink-consumer/assets/120574160/95a1fa38-5e67-4def-a694-4891d8487b4d">
